### PR TITLE
linopen: Made match_regexp() return only the first match

### DIFF
--- a/linopen/open
+++ b/linopen/open
@@ -21,11 +21,14 @@ getconfig() {
 # match regexp
 # $1 = filename
 match_regexp() {
+   open_with=''
    getconfig | grep "^?" | while read cf; do
       exp="$(echo "$cf" | sed "s/?'\(.*\)':.*/\1/")"
       [[ -n "$(echo "$@" | grep "$exp")" ]] && {
-         echo "$cf" | sed "s/?'.*':\(.*\)/\1/"
+         open_with="$(echo "$cf" | sed "s/?'.*':\(.*\)/\1/")";
       }
+      # exit the loop once a match is encountered
+      [[ ! "${open_with}" = '' ]] && echo "${open_with}" && exit 0
    done
 }
 


### PR DESCRIPTION
Before, if multiple lines matched, opening would fail altogether.
Also, this allows giving priority to certain matches over others.
Furthermore, it saves some iterations.

(I usually avoid exiting a loop in such a manner, but I wanted to keep my change as small as possible.)